### PR TITLE
Update the id of beradrome-x-thj

### DIFF
--- a/src/validators/bartio/defaultValidatorList.json
+++ b/src/validators/bartio/defaultValidatorList.json
@@ -266,7 +266,7 @@
       "twitter": ""
     },
     {
-      "id": "0x40495A781095932e2FC8dccA69F5e358711Fdd41",
+      "id": "0x34D023ACa5A227789B45A62D377b5B18A680BE01",
       "logoURI": "https://res.cloudinary.com/duv0g402y/raw/upload/src/assets/beradrome.jpg",
       "name": "beradrome-x-thj",
       "description": "Joint validator of Beradrome and The Honey Jar. Delegate or stay poor",


### PR DESCRIPTION
Previously beradrome-x-thj used the same id with the-honey-jar. We already changed the receipt address to 0x34D023ACa5A227789B45A62D377b5B18A680BE01 so need to update in the validator list.